### PR TITLE
dkms-open-nvidia.spec: add missing DKMS dependency

### DIFF
--- a/dkms-open-nvidia.spec
+++ b/dkms-open-nvidia.spec
@@ -26,6 +26,7 @@ Conflicts:      kmod-nvidia-latest-dkms
 Provides:       nvidia-kmod = %{?epoch:%{epoch}:}%{version}
 Requires:       nvidia-kmod-common = %{?epoch:%{epoch}:}%{version}
 Requires:       dkms
+Requires:	gcc-c++
 
 %description
 This package provides the open-source Nvidia kernel driver modules.


### PR DESCRIPTION
While working with your specfile for the open driver on RHEL8 I discovered that the package installation fails because a C++ compiler is needed. The problem occurs during the package installation step; the DKMS log shows that building failed due to `g++` being absent.

This small patch fixes the problem